### PR TITLE
refactor(validation): consolidate duplicated enum definitions

### DIFF
--- a/lib/validation/schemas/applications.ts
+++ b/lib/validation/schemas/applications.ts
@@ -5,14 +5,16 @@ import { commonSchemas } from "./common";
  * Application validation schemas
  */
 
+const statusEnum = z.enum(
+  ["applied", "assessment", "interview", "offer", "rejected", "withdrawn"],
+  {
+    errorMap: () => ({ message: "Invalid application status" }),
+  }
+);
+
 export const applicationSchemas = {
   // Status enum validation
-  status: z.enum(
-    ["applied", "assessment", "interview", "offer", "rejected", "withdrawn"],
-    {
-      errorMap: () => ({ message: "Invalid application status" }),
-    }
-  ),
+  status: statusEnum,
 
   // Base application schema (for creation)
   create: z.object({
@@ -24,16 +26,7 @@ export const applicationSchemas = {
       100,
       "Position title too long (max 100 characters)"
     ),
-    status: z
-      .enum([
-        "applied",
-        "assessment",
-        "interview",
-        "offer",
-        "rejected",
-        "withdrawn",
-      ])
-      .default("applied"),
+    status: statusEnum.default("applied"),
     appliedDate: commonSchemas.timestamp,
     nextDate: commonSchemas.timestamp.optional(),
     nextEvent: z
@@ -64,16 +57,7 @@ export const applicationSchemas = {
         .min(1, "Position title is required")
         .max(100, "Position title too long (max 100 characters)")
         .optional(),
-      status: z
-        .enum([
-          "applied",
-          "assessment",
-          "interview",
-          "offer",
-          "rejected",
-          "withdrawn",
-        ])
-        .optional(),
+      status: statusEnum.optional(),
       appliedDate: commonSchemas.timestamp.optional(),
       nextDate: commonSchemas.timestamp.nullable().optional(),
       nextEvent: z

--- a/lib/validation/schemas/documents.ts
+++ b/lib/validation/schemas/documents.ts
@@ -5,11 +5,13 @@ import { commonSchemas } from "./common";
  * Document validation schemas
  */
 
+const typeEnum = z.enum(["cv", "cover-letter", "portfolio", "other"], {
+  errorMap: () => ({ message: "Invalid document type" }),
+});
+
 export const documentSchemas = {
   // Document type enum
-  type: z.enum(["cv", "cover-letter", "portfolio", "other"], {
-    errorMap: () => ({ message: "Invalid document type" }),
-  }),
+  type: typeEnum,
 
   // Create document
   create: z.object({
@@ -17,7 +19,7 @@ export const documentSchemas = {
       255,
       "Document name too long (max 255 characters)"
     ),
-    type: z.enum(["cv", "cover-letter", "portfolio", "other"]).default("other"),
+    type: typeEnum.default("other"),
     url: commonSchemas.url, // Validate URL format while keeping it optional
     size: z
       .number()

--- a/lib/validation/schemas/settings.ts
+++ b/lib/validation/schemas/settings.ts
@@ -4,11 +4,13 @@ import { z } from "zod";
  * User settings validation schemas
  */
 
+const exportFormatEnum = z.enum(["json", "csv"], {
+  errorMap: () => ({ message: "Export format must be 'json' or 'csv'" }),
+});
+
 export const userSettingsSchemas = {
   // Export format enum
-  exportFormat: z.enum(["json", "csv"], {
-    errorMap: () => ({ message: "Export format must be 'json' or 'csv'" }),
-  }),
+  exportFormat: exportFormatEnum,
 
   // Create user settings
   create: z.object({
@@ -16,7 +18,7 @@ export const userSettingsSchemas = {
     autoSync: z.boolean().default(false),
     darkMode: z.boolean().default(true),
     emailReminders: z.boolean().default(true),
-    exportFormat: z.enum(["json", "csv"]).default("json"),
+    exportFormat: exportFormatEnum.default("json"),
     dataRetention: z
       .number()
       .int("Data retention must be a whole number")
@@ -32,7 +34,7 @@ export const userSettingsSchemas = {
       autoSync: z.boolean().optional(),
       darkMode: z.boolean().optional(),
       emailReminders: z.boolean().optional(),
-      exportFormat: z.enum(["json", "csv"]).optional(),
+      exportFormat: exportFormatEnum.optional(),
       dataRetention: z
         .number()
         .int("Data retention must be a whole number")


### PR DESCRIPTION
Define status, exportFormat, and type enums once and reuse them across schemas to eliminate duplication and improve maintainability.

Closes #14